### PR TITLE
Sugestões de atualização dos vocabulários do schema

### DIFF
--- a/src/layouts/post.html.hb
+++ b/src/layouts/post.html.hb
@@ -7,7 +7,7 @@ layout: page
       by
       <span itemprop="author" itemscope itemtype="http://schema.org/Person">
         <a rel="author" itemprop="url" href="https://github.com/{{document.author}}" target="_blank" class="author">
-          <p itemprop="name">@{{document.author}}</p>
+          <p itemprop="publisher">@{{document.author}}</p>
         </a>
         <meta itemprop="worksFor" content="Elo7 Serviços de Informática SA">
       </span>


### PR DESCRIPTION
@rapahaeru
Fiz alguns testes de análise dos metadados e vocabulários do Schema.
O resultado nos sugere utilizar os seguintes vocabulários:

💣 Image (Obrigatório, porém como aplicaria com os markdowns?)

- Publisher (obrigatório)
- Exibir as tags correspondentes para cada post , e aplicar o schema 'keywords' nelas.