### PR TITLE
[highlight-ref-code] Adicionando highlight para as referencias de código dentro dos paragrafos dos posts

### DIFF
--- a/src/assets/_colors.scss
+++ b/src/assets/_colors.scss
@@ -4,16 +4,19 @@ $colors-text: (
 	link: #359C9C,
 	white: #FFF,
 	black: #000,
+	marron: #C25,
 );
 
 $colors-border: (
 	light-gray: #E2E2E2,
 	white: #FFF,
 	lightly-dark-white: #F8F8F8,
+	gray: #e1e1e8
 );
 
 $colors-background: (
 	green: #73bebe,
+	light-gray: #f7f7f9,
 );
 
 $yellow-default: #FDB933;

--- a/src/assets/post.css.scss
+++ b/src/assets/post.css.scss
@@ -39,6 +39,7 @@ autoprefix: true
 			color: $yellow-default;
 		}
 	}
+
 	.date {
 		color: map-get($colors-text, gray);
 		font-size: 0.8em;
@@ -51,6 +52,13 @@ autoprefix: true
 		color: map-get($colors-text, gray);
 		font-weight: 300;
 		font-size: 0.9em;
+	}
+
+	p code {
+		padding: 0.2em;
+		color: map-get($colors-text, marron);
+		background-color: map-get($colors-background, light-gray);
+		border: 1px solid map-get($colors-border, gray);
 	}
 }
 


### PR DESCRIPTION
🤙  @tcelestino

Pessoal, segue uma proposta para melhorarmos a exibição de trechos de código dentro dos posts do blog. Eu particularmente acho que o espaçamento hoje não está legal, então aproveitei para acertar isso e adicionar uma "corzinha" 😄 

Acho legal falarmos com o @leoueda para bater o martelo visualmente! Sugestões são sempre bem vindas!

Antes:

![screen shot 2017-07-12 at 2 34 37 pm](https://user-images.githubusercontent.com/661255/28131415-2df89a02-6710-11e7-80d0-5354aecce379.png)

Depois:

![screen shot 2017-07-12 at 2 34 53 pm](https://user-images.githubusercontent.com/661255/28131423-321283f0-6710-11e7-8983-2463bebc9a30.png)
