### PR TITLE
[css-table] Formata <table> no detalhe de um post

### DIFF
--- a/src/assets/post.css.scss
+++ b/src/assets/post.css.scss
@@ -11,19 +11,18 @@ autoprefix: true
 	background-color: $white;
 
 	table {
-		max-width: 100%;
 		width: 100%;
 	}
 
 	thead th,
 	tbody td {
 		padding: 0.7em;
-		text-align: left;
 	}
 
 	thead th {
-		font-weight: bold;
+		font-weight: map-get($font-weight, bold);
 		vertical-align: bottom;
+		text-align: left;
 	}
 
 	tbody {

--- a/src/assets/post.css.scss
+++ b/src/assets/post.css.scss
@@ -10,6 +10,32 @@ autoprefix: true
 	padding: 1em 5%;
 	background-color: $white;
 
+	table {
+		max-width: 100%;
+		width: 100%;
+	}
+
+	thead th,
+	tbody td {
+		padding: 0.75em;
+		text-align: left;
+	}
+
+	thead th {
+		font-weight: bold;
+		vertical-align: bottom;
+	}
+
+	tbody {
+		> tr:nth-child(odd) {
+			background-color: #f9f9f9;
+		}
+
+		td {
+			border-top: 1px solid #ddd;
+		}
+	}
+
 	.title {
 		font-size: 2.1em;
 		margin-bottom: 0;

--- a/src/assets/post.css.scss
+++ b/src/assets/post.css.scss
@@ -17,7 +17,7 @@ autoprefix: true
 
 	thead th,
 	tbody td {
-		padding: 0.75em;
+		padding: 0.7em;
 		text-align: left;
 	}
 
@@ -28,11 +28,11 @@ autoprefix: true
 
 	tbody {
 		> tr:nth-child(odd) {
-			background-color: #f9f9f9;
+			background-color: $lightly-dark-white;
 		}
 
 		td {
-			border-top: 1px solid #ddd;
+			border-top: 1px solid map-get($colors-border, gray);
 		}
 	}
 


### PR DESCRIPTION
Para manter um design fluido. 

Antes:
![image](https://user-images.githubusercontent.com/190265/29041303-c560561e-7b88-11e7-9264-272e7c9f4ff8.png)

Depois:
![image](https://user-images.githubusercontent.com/190265/29041537-9b1a765e-7b89-11e7-963f-d7fd6a18d3c4.png)