### PR TITLE
[npm-run-dev] Rodando blog local sem o AMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ trecho do código
 
 ```
 npm install
-npm start
+npm run dev
 ```
 
 ### Labels do PR

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "start": "docpad run",
     "test": "docpad generate --silent --env static",
     "deploy": "npm install && docpad deploy-ghpages --silent --env static",
-    "fast-dev": "npm run clean-amp && rm -rf node_modules/docpad-plugin-tags/ && npm start --tech-elo7:amp=false"
+    "dev": "npm run clean-amp && rm -rf node_modules/docpad-plugin-tags/ && npm start --tech-elo7:amp=false"
   }
 }


### PR DESCRIPTION
👍  @leonardosouza

Já existia o comando `fast-dev`, porém acho que não estava tão intutivo, dai alterei para `dev` e também modifiquei o `README.md` para deixar mais claro que localmente é possível usar o `npm run dev`, assim carregando mais rapidamente o docpad.

@tcelestino