### PR TITLE
Adiciona checks para falhar o build caso dê erro na geração dos posts

### DIFF
--- a/publish_to_ghpages.sh
+++ b/publish_to_ghpages.sh
@@ -17,8 +17,8 @@ echo "Removing existing files"
 rm -rf public/*
 
 echo "Generating site"
-npm run build
-hugo --config config.prod.toml
+npm run build || exit 1
+hugo --config config.prod.toml || exit 1
 
 echo "Updating gh-pages branch"
 cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)"


### PR DESCRIPTION
Evita que o build quebre e mesmo assim o processo de publicação de post siga. Quando o build dá erro e a publicação segue, o blog **fica fora do ar**. O último post dava erro no build e não percebemos isso pois só revisamos os arquivos `.md` sem subir o blog localmente. Esse PR corrige um dos problemas nesse caso, que é a publicação, mas outro PR para adicionar uma checagem automática dos PRs pode ser interessante também.